### PR TITLE
Correção de bug no menu

### DIFF
--- a/app/src/controllers/menu_controller.js
+++ b/app/src/controllers/menu_controller.js
@@ -28,8 +28,9 @@ function escapeMenu(key) {
 
 function exitMenu(target) {
   const isNavlink = target.parentNode === navlinks;
+  const isExpanded = navbar.classList.contains("expanded");
 
-  if (!isNavlink) {
+  if (!isNavlink || !isExpanded) {
     return;
   }
 


### PR DESCRIPTION
# Correção de bug no menu

Ao selecionar um link da barra de navegação fora do contexto de menu mobile, o código não estava levando em conta essa condição e estava escondendo o conteúdo e expandindo a navegação mesmo no layout desktop.